### PR TITLE
Added security check as required from draft-faltstrom-base45-06

### DIFF
--- a/src/main/java/nl/minvws/encoding/Base45.java
+++ b/src/main/java/nl/minvws/encoding/Base45.java
@@ -156,6 +156,9 @@ public class Base45 {
             int wholeChunkLength = wholeChunkCount * EncodedChunkSize;
             for (int i = 0;  i < wholeChunkLength; ) {
                 int val = buffer[i++] + BaseSize * buffer[i++] + BaseSize * BaseSize * buffer[i++];
+                if (val > 0xFFFF) {
+                    throw new IllegalArgumentException();
+                }
                 result[resultIndex++] = (byte)(val / ByteSize);
                 result[resultIndex++] = (byte)(val % ByteSize);
             }

--- a/src/test/java/nl/minvws/encoding/Bas45Test.java
+++ b/src/test/java/nl/minvws/encoding/Bas45Test.java
@@ -45,5 +45,6 @@ public class Bas45Test {
         assertArrayEquals("Hello!!".getBytes(StandardCharsets.UTF_8), Base45.getDecoder().decode("%69 VD92EX0".getBytes(StandardCharsets.UTF_8)));
         assertThrows(NullPointerException.class, ()->{ Base45.getDecoder().decode((byte[]) null); });
         assertThrows(IllegalArgumentException.class, ()->{ Base45.getDecoder().decode("a".getBytes(StandardCharsets.UTF_8)); });
+        assertThrows(IllegalArgumentException.class, ()->{ Base45.getDecoder().decode("GGW".getBytes(StandardCharsets.UTF_8)); });
     }
 }


### PR DESCRIPTION
Hi,
as stated in [draft-faltstrom-base45-06](draft-faltstrom-base45-06), para. 6 (pag. 5, lines 1-3):

> Implementations MUST reject the encoded data if it contains a triplet of characters which, when decoded, result in an unsigned integer which is greater then _(sic)_ 65535 (ffff in base 16)

so I made the `decode()` method throw an `IllegalArgumentException` in this case.

Thank you.