### PR TITLE
Fixed ArrayIndexOutOfBoundsException due to missing unsigned conversion (Decoder)

### DIFF
--- a/src/main/java/nl/minvws/encoding/Base45.java
+++ b/src/main/java/nl/minvws/encoding/Base45.java
@@ -144,7 +144,7 @@ public class Base45 {
 
             int[] buffer = new int[src.length];
             for (int i = 0; i < src.length; ++i) {
-                buffer[i] = fromBase45[src[i]];
+                buffer[i] = fromBase45[Byte.toUnsignedInt(src[i])];
                 if (buffer[i] == -1) {
                     throw new IllegalArgumentException();
                 }

--- a/src/test/java/nl/minvws/encoding/Bas45Test.java
+++ b/src/test/java/nl/minvws/encoding/Bas45Test.java
@@ -46,5 +46,6 @@ public class Bas45Test {
         assertThrows(NullPointerException.class, ()->{ Base45.getDecoder().decode((byte[]) null); });
         assertThrows(IllegalArgumentException.class, ()->{ Base45.getDecoder().decode("a".getBytes(StandardCharsets.UTF_8)); });
         assertThrows(IllegalArgumentException.class, ()->{ Base45.getDecoder().decode("GGW".getBytes(StandardCharsets.UTF_8)); });
+        assertThrows(IllegalArgumentException.class, ()->{ Base45.getDecoder().decode("è".getBytes(StandardCharsets.ISO_8859_1)); });
     }
 }


### PR DESCRIPTION
Exception at `nl.minvws.encoding.Base45$Decoder.decode(Base45.java:147)`

Now the array lookup works correctly and the `decode` method throws `IllegalArgumentException` when the input byte array contains a value greater than `127` (`0x7f`).

Test failure before the fix: `org.opentest4j.AssertionFailedError: Unexpected exception type thrown ==> expected: <java.lang.IllegalArgumentException> but was: <java.lang.ArrayIndexOutOfBoundsException>`

Thank you again.